### PR TITLE
Increased DHCP client tolerance of slow link init.

### DIFF
--- a/holos/rust/holos-config/src/main.rs
+++ b/holos/rust/holos-config/src/main.rs
@@ -219,7 +219,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         format!("/etc/init.d/net.{}", interface),
                     )
                     .ok();
-                    let netifrc_stanza = format!("config_{}=\"dhcp\"\n", interface);
+                    // TODO: This is not necessary for each boot when the OS is installed. We
+                    // should first check for a `config_XXX` line for our interface first, and
+                    // replace it if present, or append it if not. The code below is fine. It just
+                    // appends a duplicate line each boot.
+                    let netifrc_stanza = format!(
+                        "config_{}=\"dhcp\"\nudhcpc_{}=\"-b -t 7\"\n",
+                        interface, interface
+                    );
                     let mut file = OpenOptions::new()
                         .append(true)
                         .create(false)


### PR DESCRIPTION
Closes #85 . I've tested that the DHCP client takes longer to time out, but can't reproduce the community member's specific circumstances. Commit also adds a note for later improvement that wasn't critical for now.