### PR TITLE
feat(tofu): add DEPLOYMENT KV namespace for per-deployment metadata

### DIFF
--- a/deploy/tofu/cloudflare.tf
+++ b/deploy/tofu/cloudflare.tf
@@ -24,11 +24,21 @@ provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
 
-# ── KV namespace: SESSIONS (joining service) ────────────────────────────────
+# ── KV namespace: SESSIONS (joining service runtime) ───────────────────────
 
 resource "cloudflare_workers_kv_namespace" "sessions" {
   account_id = var.cloudflare_account_id
   title      = "${var.project_name}-sessions"
+}
+
+# ── KV namespace: DEPLOYMENT (per-deployment metadata) ─────────────────────
+# Holds provisioning-time config written by scripts and read by the control
+# plane — not bound to any Worker. Keys: network_seed, joining_key_pub,
+# harvester_ip, bootstrap_result.
+
+resource "cloudflare_workers_kv_namespace" "deployment" {
+  account_id = var.cloudflare_account_id
+  title      = "${var.project_name}-deployment"
 }
 
 # ── Log-collector Worker ────────────────────────────────────────────────────

--- a/deploy/tofu/outputs.tf
+++ b/deploy/tofu/outputs.tf
@@ -19,8 +19,13 @@ output "log_collector_url" {
 }
 
 output "sessions_kv_namespace_id" {
-  description = "SESSIONS KV namespace ID (pass to joining service wrangler deploy)"
+  description = "SESSIONS KV namespace ID (joining service runtime)"
   value       = cloudflare_workers_kv_namespace.sessions.id
+}
+
+output "deployment_kv_namespace_id" {
+  description = "DEPLOYMENT KV namespace ID (per-deployment metadata store)"
+  value       = cloudflare_workers_kv_namespace.deployment.id
 }
 
 output "volume_ids" {


### PR DESCRIPTION
## Summary

- Provisions a second KV namespace (`DEPLOYMENT`) alongside `SESSIONS`, not bound to any Worker
- Holds provisioning-time state written by `hdeploy` and read by the future control plane: `network_seed`, `joining_key_pub`, `harvester_ip`, `bootstrap_result`
- Exports `deployment_kv_namespace_id` as a tofu output so automation can resolve the namespace ID without hardcoding

## Context

`hdeploy` (`holo-platform-cli`) reads `deployment_kv_namespace_id` from `tofu output -json` to know where to write and read per-deployment KV entries. This IaC change provisions the namespace and wires up the output.

## Test plan

- [ ] `tofu plan` shows a new `cloudflare_workers_kv_namespace` resource and the `deployment_kv_namespace_id` output
- [ ] After `tofu apply`, `tofu output deployment_kv_namespace_id` returns a non-empty namespace ID
- [ ] `hdeploy init-deployment` can write `network_seed` to the namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)