### PR TITLE
chore(docker): upgrade Holochain to stable 0.6.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,8 +18,8 @@ RUN case "${TARGETARCH}" in \
     tar -C / -Jxpf s6-overlay-${S6_ARCH}.tar.xz && \
     rm -f s6-overlay-*.tar.xz
 
-ARG HOLOCHAIN_VERSION=0.6.1-rc.3
-ARG HC_VERSION=0.6.1-rc.3
+ARG HOLOCHAIN_VERSION=0.6.1
+ARG HC_VERSION=0.6.1
 
 RUN case "${TARGETARCH}" in \
     amd64) HC_ARCH="x86_64-unknown-linux-gnu" ;; \

--- a/docker/Dockerfile.harvester
+++ b/docker/Dockerfile.harvester
@@ -26,8 +26,8 @@ RUN case "${TARGETARCH}" in \
     tar -C / -Jxpf s6-overlay-${S6_ARCH}.tar.xz && \
     rm -f s6-overlay-*.tar.xz
 
-ARG HOLOCHAIN_VERSION=0.6.1-rc.3
-ARG HC_VERSION=0.6.1-rc.3
+ARG HOLOCHAIN_VERSION=0.6.1
+ARG HC_VERSION=0.6.1
 
 RUN case "${TARGETARCH}" in \
     amd64) HC_ARCH="x86_64-unknown-linux-gnu" ;; \


### PR DESCRIPTION
## Summary

- Bumps `HOLOCHAIN_VERSION` and `HC_VERSION` from `0.6.1-rc.3` to `0.6.1` in `docker/Dockerfile` and `docker/Dockerfile.harvester`
- The stable release is available at https://github.com/holochain/holochain/releases/tag/holochain-0.6.1 with the same binary naming convention (`holochain-{arch}`, `hc-{arch}`)

## Test plan

- [ ] CI builds both Docker images successfully against the stable release binaries
- [ ] Rebuilt images pass smoke tests (conductor starts, admin WebSocket responds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)